### PR TITLE
feat: write jobs to sqs queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run typecheck
-      # ts-standard is not having a good time yet.
-      # - run: npm run lint
+      - run: npm run lint
 
   test:
     runs-on: ubuntu-latest

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "scripts": {},
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.110.0",
+    "@aws-sdk/client-sqs": "^3.121.0",
     "@aws-sdk/lib-dynamodb": "^3.112.0",
     "aws-sdk": "^2.1145.0",
     "nanoid": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.110.0",
+        "@aws-sdk/client-sqs": "^3.121.0",
         "@aws-sdk/lib-dynamodb": "^3.112.0",
         "aws-sdk": "^2.1145.0",
         "nanoid": "^4.0.0",
@@ -248,6 +249,246 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.121.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.121.0.tgz",
+      "integrity": "sha512-O9wYxB5/BxDEHxIUgy90onGG7EKQoNvwtw47yasQN6rfiE87xHItDmOunDT4xnK7nGwTILfmg28MdUDeBdDchQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.121.0",
+        "@aws-sdk/config-resolver": "3.110.0",
+        "@aws-sdk/credential-provider-node": "3.121.0",
+        "@aws-sdk/fetch-http-handler": "3.110.0",
+        "@aws-sdk/hash-node": "3.110.0",
+        "@aws-sdk/invalid-dependency": "3.110.0",
+        "@aws-sdk/md5-js": "3.110.0",
+        "@aws-sdk/middleware-content-length": "3.110.0",
+        "@aws-sdk/middleware-host-header": "3.110.0",
+        "@aws-sdk/middleware-logger": "3.110.0",
+        "@aws-sdk/middleware-recursion-detection": "3.110.0",
+        "@aws-sdk/middleware-retry": "3.118.1",
+        "@aws-sdk/middleware-sdk-sqs": "3.110.0",
+        "@aws-sdk/middleware-serde": "3.110.0",
+        "@aws-sdk/middleware-signing": "3.110.0",
+        "@aws-sdk/middleware-stack": "3.110.0",
+        "@aws-sdk/middleware-user-agent": "3.110.0",
+        "@aws-sdk/node-config-provider": "3.110.0",
+        "@aws-sdk/node-http-handler": "3.118.1",
+        "@aws-sdk/protocol-http": "3.110.0",
+        "@aws-sdk/smithy-client": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/url-parser": "3.110.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
+        "@aws-sdk/util-defaults-mode-node": "3.110.0",
+        "@aws-sdk/util-user-agent-browser": "3.110.0",
+        "@aws-sdk/util-user-agent-node": "3.118.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.121.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.121.0.tgz",
+      "integrity": "sha512-uYkeUdNnEla57g4QZT0Cu5ll+m0fUQJPkoTXQI5QKeLH2usVpmrCRbtTWEVTh94Gf2x/HK8Ifu7eO/0PquwwIQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.110.0",
+        "@aws-sdk/fetch-http-handler": "3.110.0",
+        "@aws-sdk/hash-node": "3.110.0",
+        "@aws-sdk/invalid-dependency": "3.110.0",
+        "@aws-sdk/middleware-content-length": "3.110.0",
+        "@aws-sdk/middleware-host-header": "3.110.0",
+        "@aws-sdk/middleware-logger": "3.110.0",
+        "@aws-sdk/middleware-recursion-detection": "3.110.0",
+        "@aws-sdk/middleware-retry": "3.118.1",
+        "@aws-sdk/middleware-serde": "3.110.0",
+        "@aws-sdk/middleware-stack": "3.110.0",
+        "@aws-sdk/middleware-user-agent": "3.110.0",
+        "@aws-sdk/node-config-provider": "3.110.0",
+        "@aws-sdk/node-http-handler": "3.118.1",
+        "@aws-sdk/protocol-http": "3.110.0",
+        "@aws-sdk/smithy-client": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/url-parser": "3.110.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
+        "@aws-sdk/util-defaults-mode-node": "3.110.0",
+        "@aws-sdk/util-user-agent-browser": "3.110.0",
+        "@aws-sdk/util-user-agent-node": "3.118.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
+      "version": "3.121.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.121.0.tgz",
+      "integrity": "sha512-ZqEcxfeYVeSo/VyXSI4XW4MsWYoRmEdxRLWwI7kgFQxgqwVtfhPmvcaw6CA1atMcSR6waiRSpe9pgpj6gKJvyw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.110.0",
+        "@aws-sdk/credential-provider-node": "3.121.0",
+        "@aws-sdk/fetch-http-handler": "3.110.0",
+        "@aws-sdk/hash-node": "3.110.0",
+        "@aws-sdk/invalid-dependency": "3.110.0",
+        "@aws-sdk/middleware-content-length": "3.110.0",
+        "@aws-sdk/middleware-host-header": "3.110.0",
+        "@aws-sdk/middleware-logger": "3.110.0",
+        "@aws-sdk/middleware-recursion-detection": "3.110.0",
+        "@aws-sdk/middleware-retry": "3.118.1",
+        "@aws-sdk/middleware-sdk-sts": "3.110.0",
+        "@aws-sdk/middleware-serde": "3.110.0",
+        "@aws-sdk/middleware-signing": "3.110.0",
+        "@aws-sdk/middleware-stack": "3.110.0",
+        "@aws-sdk/middleware-user-agent": "3.110.0",
+        "@aws-sdk/node-config-provider": "3.110.0",
+        "@aws-sdk/node-http-handler": "3.118.1",
+        "@aws-sdk/protocol-http": "3.110.0",
+        "@aws-sdk/smithy-client": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/url-parser": "3.110.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
+        "@aws-sdk/util-defaults-mode-node": "3.110.0",
+        "@aws-sdk/util-user-agent-browser": "3.110.0",
+        "@aws-sdk/util-user-agent-node": "3.118.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.121.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.121.0.tgz",
+      "integrity": "sha512-wOuGOifwZtTN/prCaG+hO9AtpKjJB/QyRse251+I+inNPg2iSd9rCLfHZdmfL/Zn2XJyfg0ULOl6c/myF5aRDg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.110.0",
+        "@aws-sdk/credential-provider-imds": "3.110.0",
+        "@aws-sdk/credential-provider-sso": "3.121.0",
+        "@aws-sdk/credential-provider-web-identity": "3.110.0",
+        "@aws-sdk/property-provider": "3.110.0",
+        "@aws-sdk/shared-ini-file-loader": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.121.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.121.0.tgz",
+      "integrity": "sha512-wY5+oey0eoxkGMTXrZ+tK7FKA91WN8ntBbYBbZL0vktHYCQkBra5fBGV17RNp8ggVkJXAtDdrIjTBEQ/vNrMrQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.110.0",
+        "@aws-sdk/credential-provider-imds": "3.110.0",
+        "@aws-sdk/credential-provider-ini": "3.121.0",
+        "@aws-sdk/credential-provider-process": "3.110.0",
+        "@aws-sdk/credential-provider-sso": "3.121.0",
+        "@aws-sdk/credential-provider-web-identity": "3.110.0",
+        "@aws-sdk/property-provider": "3.110.0",
+        "@aws-sdk/shared-ini-file-loader": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.121.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.121.0.tgz",
+      "integrity": "sha512-c9XmnndZmJdkSBgDpVQCN8fcVTkRrtDWNUBO6TcA0abxGOOteUS7s9YmJKqMuwABzk+WGJ1B2EVC5b0AMzIFYg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.121.0",
+        "@aws-sdk/property-provider": "3.110.0",
+        "@aws-sdk/shared-ini-file-loader": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.118.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.118.1.tgz",
+      "integrity": "sha512-Dh0EgO3yPHEaRC6CVrofgAMdUQaG0Kkl466iVFHN5n5kExQvCtvpMHwO9N7kqaq9lXten3yhzboRNLIo98E1Kw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.110.0",
+        "@aws-sdk/service-error-classification": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/util-middleware": "3.110.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.118.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.118.1.tgz",
+      "integrity": "sha512-pfWVAUNJEs0UW0KkDqq2/VCz9PIpvg4mYEfCVZ4jR+Rv8F7UezNeM3FrEdHk8dfYShH+OV0hFskHBQJhw1BX2Q==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.110.0",
+        "@aws-sdk/protocol-http": "3.110.0",
+        "@aws-sdk/querystring-builder": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.118.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.118.0.tgz",
+      "integrity": "sha512-7j21HNumxMkeUpgoMX8o3y66k+qMSEkCPCMGnoiiMtgfWX9SY0S/fLwR1nDBw8HI3NthRXfgWdAXUu8K3Kjp6g==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -534,6 +775,17 @@
         "@aws-sdk/types": "^3.0.0"
       }
     },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.110.0.tgz",
+      "integrity": "sha512-66gV6CH8O7ymTZMIbGjdUI71K7ErDfudhtN/ULb97kD2TYX4NlFtxNZxx3+iZH1G0H636lWm9hJcU5ELG9B+bw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.110.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.110.0.tgz",
@@ -611,6 +863,19 @@
         "@aws-sdk/util-middleware": "3.110.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.110.0.tgz",
+      "integrity": "sha512-eDk5WEv8TM75JyN/SiAAd5+ELO/NQYZ6a1wFrA8EzTq18H3UJImcYWuZq6QU8ZD07E48dlA47JzQg7lClDqnIA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/util-hex-encoding": "3.109.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -9895,6 +10160,213 @@
         "uuid": "^8.3.2"
       }
     },
+    "@aws-sdk/client-sqs": {
+      "version": "3.121.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.121.0.tgz",
+      "integrity": "sha512-O9wYxB5/BxDEHxIUgy90onGG7EKQoNvwtw47yasQN6rfiE87xHItDmOunDT4xnK7nGwTILfmg28MdUDeBdDchQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.121.0",
+        "@aws-sdk/config-resolver": "3.110.0",
+        "@aws-sdk/credential-provider-node": "3.121.0",
+        "@aws-sdk/fetch-http-handler": "3.110.0",
+        "@aws-sdk/hash-node": "3.110.0",
+        "@aws-sdk/invalid-dependency": "3.110.0",
+        "@aws-sdk/md5-js": "3.110.0",
+        "@aws-sdk/middleware-content-length": "3.110.0",
+        "@aws-sdk/middleware-host-header": "3.110.0",
+        "@aws-sdk/middleware-logger": "3.110.0",
+        "@aws-sdk/middleware-recursion-detection": "3.110.0",
+        "@aws-sdk/middleware-retry": "3.118.1",
+        "@aws-sdk/middleware-sdk-sqs": "3.110.0",
+        "@aws-sdk/middleware-serde": "3.110.0",
+        "@aws-sdk/middleware-signing": "3.110.0",
+        "@aws-sdk/middleware-stack": "3.110.0",
+        "@aws-sdk/middleware-user-agent": "3.110.0",
+        "@aws-sdk/node-config-provider": "3.110.0",
+        "@aws-sdk/node-http-handler": "3.118.1",
+        "@aws-sdk/protocol-http": "3.110.0",
+        "@aws-sdk/smithy-client": "3.110.0",
+        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/url-parser": "3.110.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
+        "@aws-sdk/util-defaults-mode-node": "3.110.0",
+        "@aws-sdk/util-user-agent-browser": "3.110.0",
+        "@aws-sdk/util-user-agent-node": "3.118.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.121.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.121.0.tgz",
+          "integrity": "sha512-uYkeUdNnEla57g4QZT0Cu5ll+m0fUQJPkoTXQI5QKeLH2usVpmrCRbtTWEVTh94Gf2x/HK8Ifu7eO/0PquwwIQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.110.0",
+            "@aws-sdk/fetch-http-handler": "3.110.0",
+            "@aws-sdk/hash-node": "3.110.0",
+            "@aws-sdk/invalid-dependency": "3.110.0",
+            "@aws-sdk/middleware-content-length": "3.110.0",
+            "@aws-sdk/middleware-host-header": "3.110.0",
+            "@aws-sdk/middleware-logger": "3.110.0",
+            "@aws-sdk/middleware-recursion-detection": "3.110.0",
+            "@aws-sdk/middleware-retry": "3.118.1",
+            "@aws-sdk/middleware-serde": "3.110.0",
+            "@aws-sdk/middleware-stack": "3.110.0",
+            "@aws-sdk/middleware-user-agent": "3.110.0",
+            "@aws-sdk/node-config-provider": "3.110.0",
+            "@aws-sdk/node-http-handler": "3.118.1",
+            "@aws-sdk/protocol-http": "3.110.0",
+            "@aws-sdk/smithy-client": "3.110.0",
+            "@aws-sdk/types": "3.110.0",
+            "@aws-sdk/url-parser": "3.110.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "@aws-sdk/util-base64-node": "3.55.0",
+            "@aws-sdk/util-body-length-browser": "3.55.0",
+            "@aws-sdk/util-body-length-node": "3.55.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.110.0",
+            "@aws-sdk/util-defaults-mode-node": "3.110.0",
+            "@aws-sdk/util-user-agent-browser": "3.110.0",
+            "@aws-sdk/util-user-agent-node": "3.118.0",
+            "@aws-sdk/util-utf8-browser": "3.109.0",
+            "@aws-sdk/util-utf8-node": "3.109.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.121.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.121.0.tgz",
+          "integrity": "sha512-ZqEcxfeYVeSo/VyXSI4XW4MsWYoRmEdxRLWwI7kgFQxgqwVtfhPmvcaw6CA1atMcSR6waiRSpe9pgpj6gKJvyw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.110.0",
+            "@aws-sdk/credential-provider-node": "3.121.0",
+            "@aws-sdk/fetch-http-handler": "3.110.0",
+            "@aws-sdk/hash-node": "3.110.0",
+            "@aws-sdk/invalid-dependency": "3.110.0",
+            "@aws-sdk/middleware-content-length": "3.110.0",
+            "@aws-sdk/middleware-host-header": "3.110.0",
+            "@aws-sdk/middleware-logger": "3.110.0",
+            "@aws-sdk/middleware-recursion-detection": "3.110.0",
+            "@aws-sdk/middleware-retry": "3.118.1",
+            "@aws-sdk/middleware-sdk-sts": "3.110.0",
+            "@aws-sdk/middleware-serde": "3.110.0",
+            "@aws-sdk/middleware-signing": "3.110.0",
+            "@aws-sdk/middleware-stack": "3.110.0",
+            "@aws-sdk/middleware-user-agent": "3.110.0",
+            "@aws-sdk/node-config-provider": "3.110.0",
+            "@aws-sdk/node-http-handler": "3.118.1",
+            "@aws-sdk/protocol-http": "3.110.0",
+            "@aws-sdk/smithy-client": "3.110.0",
+            "@aws-sdk/types": "3.110.0",
+            "@aws-sdk/url-parser": "3.110.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "@aws-sdk/util-base64-node": "3.55.0",
+            "@aws-sdk/util-body-length-browser": "3.55.0",
+            "@aws-sdk/util-body-length-node": "3.55.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.110.0",
+            "@aws-sdk/util-defaults-mode-node": "3.110.0",
+            "@aws-sdk/util-user-agent-browser": "3.110.0",
+            "@aws-sdk/util-user-agent-node": "3.118.0",
+            "@aws-sdk/util-utf8-browser": "3.109.0",
+            "@aws-sdk/util-utf8-node": "3.109.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.121.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.121.0.tgz",
+          "integrity": "sha512-wOuGOifwZtTN/prCaG+hO9AtpKjJB/QyRse251+I+inNPg2iSd9rCLfHZdmfL/Zn2XJyfg0ULOl6c/myF5aRDg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.110.0",
+            "@aws-sdk/credential-provider-imds": "3.110.0",
+            "@aws-sdk/credential-provider-sso": "3.121.0",
+            "@aws-sdk/credential-provider-web-identity": "3.110.0",
+            "@aws-sdk/property-provider": "3.110.0",
+            "@aws-sdk/shared-ini-file-loader": "3.110.0",
+            "@aws-sdk/types": "3.110.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.121.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.121.0.tgz",
+          "integrity": "sha512-wY5+oey0eoxkGMTXrZ+tK7FKA91WN8ntBbYBbZL0vktHYCQkBra5fBGV17RNp8ggVkJXAtDdrIjTBEQ/vNrMrQ==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.110.0",
+            "@aws-sdk/credential-provider-imds": "3.110.0",
+            "@aws-sdk/credential-provider-ini": "3.121.0",
+            "@aws-sdk/credential-provider-process": "3.110.0",
+            "@aws-sdk/credential-provider-sso": "3.121.0",
+            "@aws-sdk/credential-provider-web-identity": "3.110.0",
+            "@aws-sdk/property-provider": "3.110.0",
+            "@aws-sdk/shared-ini-file-loader": "3.110.0",
+            "@aws-sdk/types": "3.110.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.121.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.121.0.tgz",
+          "integrity": "sha512-c9XmnndZmJdkSBgDpVQCN8fcVTkRrtDWNUBO6TcA0abxGOOteUS7s9YmJKqMuwABzk+WGJ1B2EVC5b0AMzIFYg==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.121.0",
+            "@aws-sdk/property-provider": "3.110.0",
+            "@aws-sdk/shared-ini-file-loader": "3.110.0",
+            "@aws-sdk/types": "3.110.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.118.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.118.1.tgz",
+          "integrity": "sha512-Dh0EgO3yPHEaRC6CVrofgAMdUQaG0Kkl466iVFHN5n5kExQvCtvpMHwO9N7kqaq9lXten3yhzboRNLIo98E1Kw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.110.0",
+            "@aws-sdk/service-error-classification": "3.110.0",
+            "@aws-sdk/types": "3.110.0",
+            "@aws-sdk/util-middleware": "3.110.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.118.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.118.1.tgz",
+          "integrity": "sha512-pfWVAUNJEs0UW0KkDqq2/VCz9PIpvg4mYEfCVZ4jR+Rv8F7UezNeM3FrEdHk8dfYShH+OV0hFskHBQJhw1BX2Q==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.110.0",
+            "@aws-sdk/protocol-http": "3.110.0",
+            "@aws-sdk/querystring-builder": "3.110.0",
+            "@aws-sdk/types": "3.110.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.118.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.118.0.tgz",
+          "integrity": "sha512-7j21HNumxMkeUpgoMX8o3y66k+qMSEkCPCMGnoiiMtgfWX9SY0S/fLwR1nDBw8HI3NthRXfgWdAXUu8K3Kjp6g==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.110.0",
+            "@aws-sdk/types": "3.110.0",
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
     "@aws-sdk/client-sso": {
       "version": "3.110.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.110.0.tgz",
@@ -10132,6 +10604,17 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/md5-js": {
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.110.0.tgz",
+      "integrity": "sha512-66gV6CH8O7ymTZMIbGjdUI71K7ErDfudhtN/ULb97kD2TYX4NlFtxNZxx3+iZH1G0H636lWm9hJcU5ELG9B+bw==",
+      "requires": {
+        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/middleware-content-length": {
       "version": "3.110.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.110.0.tgz",
@@ -10194,6 +10677,16 @@
         "@aws-sdk/util-middleware": "3.110.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.110.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.110.0.tgz",
+      "integrity": "sha512-eDk5WEv8TM75JyN/SiAAd5+ELO/NQYZ6a1wFrA8EzTq18H3UJImcYWuZq6QU8ZD07E48dlA47JzQg7lClDqnIA==",
+      "requires": {
+        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/util-hex-encoding": "3.109.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
@@ -10714,6 +11207,7 @@
       "version": "file:backend",
       "requires": {
         "@aws-sdk/client-dynamodb": "^3.110.0",
+        "@aws-sdk/client-sqs": "*",
         "@aws-sdk/lib-dynamodb": "^3.112.0",
         "@types/aws-lambda": "^8.10.97",
         "@types/node": "^18.0.0",

--- a/stacks/PinningServiceStack.ts
+++ b/stacks/PinningServiceStack.ts
@@ -1,9 +1,11 @@
-import { StackContext, Api, Table, Queue } from '@serverless-stack/resources'
+import { StackContext, Api, Table, Queue, Bucket } from '@serverless-stack/resources'
 
-export function PinningServiceStack ({ stack }: StackContext): { table: Table, queue: Queue } {
+export function PinningServiceStack ({ stack }: StackContext): { queue: Queue, bucket: Bucket } {
   const queue = new Queue(stack, 'Pin')
 
-  const table = new Table(stack, 'PinStatusv4', {
+  const bucket = new Bucket(stack, 'Car')
+
+  const table = new Table(stack, 'PinStatusv5', {
     fields: {
       requestid: 'string',
       userid: 'string'
@@ -20,6 +22,7 @@ export function PinningServiceStack ({ stack }: StackContext): { table: Table, q
       function: {
         permissions: [table, queue], // Allow the API to access the table and topic
         environment: {
+          BUCKET_NAME: bucket.bucketName,
           TABLE_NAME: table.tableName,
           QUEUE_URL: queue.queueUrl
         }
@@ -42,7 +45,7 @@ export function PinningServiceStack ({ stack }: StackContext): { table: Table, q
   })
 
   return {
-    table,
-    queue
+    queue,
+    bucket
   }
 }

--- a/stacks/lib/queue-processing-fargate-service.ts
+++ b/stacks/lib/queue-processing-fargate-service.ts
@@ -1,4 +1,4 @@
-// Forked from https://github.com/aws/aws-cdk/blob/f2b4effc903ab3a36dc925516f3329f236d03a70/packages/%40aws-cdk/aws-ecs-patterns/lib/fargate/queue-processing-fargate-service.ts
+// Forked from https://github.com/aws/aws-cdk/blob/f2b  4effc903ab3a36dc925516f3329f236d03a70/packages/%40aws-cdk/aws-ecs-patterns/lib/fargate/queue-processing-fargate-service.ts
 // Adds `ephemeralStorageGiB` property to the Service, passed thru to FargateTaskDefinition
 // Official support is stuck in a stalled PR here https://github.com/aws/aws-cdk/pull/18106
 import * as ec2 from 'aws-cdk-lib/aws-ec2'
@@ -168,7 +168,7 @@ export class QueueProcessingFargateService extends QueueProcessingServiceBase {
       vpcSubnets: props.taskSubnets,
       assignPublicIp: props.assignPublicIp,
       circuitBreaker: props.circuitBreaker,
-      capacityProviderStrategies: props.capacityProviderStrategies,
+      capacityProviderStrategies: props.capacityProviderStrategies
       // enableExecuteCommand: props.enableExecuteCommand
     })
 

--- a/stacks/lib/queue-processing-fargate-service.ts
+++ b/stacks/lib/queue-processing-fargate-service.ts
@@ -1,4 +1,4 @@
-// Forked from https://github.com/aws/aws-cdk/blob/f2b  4effc903ab3a36dc925516f3329f236d03a70/packages/%40aws-cdk/aws-ecs-patterns/lib/fargate/queue-processing-fargate-service.ts
+// Forked from https://github.com/aws/aws-cdk/blob/f2b4effc903ab3a36dc925516f3329f236d03a70/packages/%40aws-cdk/aws-ecs-patterns/lib/fargate/queue-processing-fargate-service.ts
 // Adds `ephemeralStorageGiB` property to the Service, passed thru to FargateTaskDefinition
 // Official support is stuck in a stalled PR here https://github.com/aws/aws-cdk/pull/18106
 import * as ec2 from 'aws-cdk-lib/aws-ec2'


### PR DESCRIPTION
IT WORKS ✨🎷🐩

when linked up to the https://github.com/olizilla/pickup this PR has succesfully turned a pin request api call into a dynamoDB record and an SQS Queue message. Pickup pulled the message, fetched the cid via the local go-ipfs sidecar and uploaded the CAR to s3.

from this request
<img width="858" alt="Screenshot 2022-07-07 at 16 45 43" src="https://user-images.githubusercontent.com/58871/177816006-7f22d989-f03e-42ac-9a67-052927d4e59e.png">

to this stored CAR
<img width="891" alt="Screenshot 2022-07-07 at 16 39 35" src="https://user-images.githubusercontent.com/58871/177815737-aa30bcb9-9942-42d0-bb9c-0afd1664f9ab.png">

_momentus_

Next up, consolidate https://github.com/olizilla/pickup & https://github.com/olizilla/pickup-api into a mono-repo so they can be deployed together more reasonably.

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>